### PR TITLE
Made image layout responsive and random selections distinct

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,7 +67,11 @@ export default {
       displayNewImages: function() {
           let count = this.views.length;
           let image1 = Math.floor((Math.random() * count));
-          let image2 = Math.floor((Math.random() * count));
+          let image2;
+          do {
+            image2 = Math.floor((Math.random() * count));
+          }
+          while (count > 1 && image1 == image2);
           this.viewPair = [this.views[image1], this.views[image2]];
           //return viewPair;
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <div class="d-flex justify-content-center">
+    <div class="d-flex flex-wrap flex-sm-nowrap justify-content-center">
     <ScenicView v-for="view in viewPair"
                 :key="view.id"
                 v-bind:view="view"
@@ -69,6 +69,7 @@ export default {
           let image1 = Math.floor((Math.random() * count));
           let image2 = Math.floor((Math.random() * count));
           this.viewPair = [this.views[image1], this.views[image2]];
+          //return viewPair;
       }
   },
   beforeMount: function() {

--- a/src/components/ScenicView.vue
+++ b/src/components/ScenicView.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="scenic-view">
+  <div class="scenic-view p-2">
     <figure>
-    <img v-bind:alt="view.title" :src="require(`../assets/${view.imgUrl}`)" />
+    <img class="img-fluid" v-bind:alt="view.title" :src="require(`../assets/${view.imgUrl}`)" />
     <figcaption>
     <label>
     <input type="radio" name="vote" v-bind:value="view.id" v-on:click="$emit('voted')" />


### PR DESCRIPTION
I used some of the Bootstrap 4 flex-wrap and img-fluid classes to make the images resize responsively, and stack on smaller screens.

For the random image selector, the do-while loop ensures image2 will not be the same as image1. The `count > 1` prevents an infinite loop if there happens to be one or no photos in the array.